### PR TITLE
Frontend Unit Test update 12 April 2020

### DIFF
--- a/FRONTEND/newFrontEnd/apTime/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/FRONTEND/newFrontEnd/apTime/src/app/components/dashboard/dashboard.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';
 import { MatDatepicker } from '@angular/material/datepicker';
 import { MatIconModule} from '@angular/material/icon';
 import {CustomMaterialModule} from '../../modules/material.module';
@@ -8,7 +8,6 @@ import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@ang
 import {RouterTestingModule} from '@angular/router/testing';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
 import {
   MatFormFieldModule,
   MatInputModule,
@@ -21,19 +20,21 @@ import {
   MatSelectModule
 } from '@angular/material';
 import { DashboardComponent } from './dashboard.component';
-import {FormControl} from "@angular/forms";
-import {EMPTY} from "rxjs";
+import {FormControl} from '@angular/forms';
+import {EMPTY} from 'rxjs';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.resetTestEnvironment();
     TestBed.initTestEnvironment(BrowserDynamicTestingModule,
         platformBrowserDynamicTesting());
     TestBed.configureTestingModule({
-      imports: [ HttpClientModule, BrowserAnimationsModule,
+      imports: [ HttpClientTestingModule, BrowserAnimationsModule,
         RouterTestingModule.withRoutes([]),
         MatIconModule,
         MatSelectModule,
@@ -43,7 +44,7 @@ describe('DashboardComponent', () => {
         MatDialogModule,
         MatMenuModule
       ],
-      providers: [AmplifyService, HttpClient, {
+      providers: [AmplifyService, {
         provide: MatDialogRef,
         useValue: {}},
         { provide: MAT_DIALOG_DATA, useValue: {}}],
@@ -57,6 +58,7 @@ describe('DashboardComponent', () => {
     fixture = TestBed.createComponent(DashboardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    httpMock = getTestBed().get(HttpTestingController);
   });
 
   it('should create component', () => {

--- a/FRONTEND/newFrontEnd/apTime/src/app/components/start-task-dialog/start-task-dialog.component.spec.ts
+++ b/FRONTEND/newFrontEnd/apTime/src/app/components/start-task-dialog/start-task-dialog.component.spec.ts
@@ -4,7 +4,7 @@
  *
  *  Unit Test - Frontend
  */
-import {async, ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, getTestBed, TestBed, tick} from '@angular/core/testing';
 import { MatIconModule} from '@angular/material/icon';
 import {CustomMaterialModule} from '../../modules/material.module';
 import {HttpClient, HttpClientModule} from '@angular/common/http';
@@ -24,6 +24,7 @@ import {
   MatRadioModule,
   MatSelectModule
 } from '@angular/material';
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {NotificationsServiceService} from '../notification';
 import {EMPTY} from 'rxjs';
 import {NotificationsComponent} from '../notification/notifications/notifications.component';
@@ -32,9 +33,10 @@ import any = jasmine.any;
 describe('StartTaskDialogComponent', () => {
   let component: StartTaskDialogComponent;
   let fixture: ComponentFixture<StartTaskDialogComponent>;
+  let httpMock: HttpTestingController;
 
   const dialogMock = {
-    close: () =>{ }
+    close: () => { }
   };
 
   beforeEach(async(() => {
@@ -42,7 +44,7 @@ describe('StartTaskDialogComponent', () => {
     TestBed.initTestEnvironment(BrowserDynamicTestingModule,
         platformBrowserDynamicTesting());
     TestBed.configureTestingModule({
-      imports: [ HttpClientModule, BrowserAnimationsModule,
+      imports: [ HttpClientTestingModule, BrowserAnimationsModule,
         RouterTestingModule.withRoutes([]),
         MatIconModule,
         MatSelectModule,
@@ -51,7 +53,7 @@ describe('StartTaskDialogComponent', () => {
         MatInputModule,
         MatDialogModule,
       ],
-      providers: [AmplifyService, HttpClient, {
+      providers: [AmplifyService, {
         provide: MatDialogRef,
         useValue: dialogMock},
         { provide: MAT_DIALOG_DATA, useValue: {}}],
@@ -64,6 +66,7 @@ describe('StartTaskDialogComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(StartTaskDialogComponent);
     component = fixture.componentInstance;
+    httpMock = getTestBed().get(HttpTestingController);
     fixture.detectChanges();
   });
 
@@ -80,14 +83,14 @@ describe('StartTaskDialogComponent', () => {
   }));
 
   it('Test onNoClick DialogRef - Close', () => {
-    let spy = spyOn(component.dialogRef, 'close').and.callThrough();
+    const spy = spyOn(component.dialogRef, 'close').and.callThrough();
     component.onNoClick();
     expect(spy).toHaveBeenCalled();
     // add expects to test that onNoClick does what it is supposed to
   });
 
   it('should call onYesClick', async(() => {
-    let spy = spyOn(component, 'onYesClick').and.callThrough();
+    const spy = spyOn(component, 'onYesClick').and.callThrough();
     component.onYesClick();
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
@@ -96,8 +99,8 @@ describe('StartTaskDialogComponent', () => {
   }));
 
   it('should call onCompleteClick', async(() => {
-    let num = 1;
-    let spy = spyOn(component, 'onCompleteClick').and.callThrough();
+    const num = 1;
+    const spy = spyOn(component, 'onCompleteClick').and.callThrough();
     component.onCompleteClick(num);
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
@@ -105,10 +108,11 @@ describe('StartTaskDialogComponent', () => {
     });
   }));
 
-  it('should call onSuspendClick', async(() => {
-    let num = 1;
-    let spy = spyOn(component, 'onSuspendClick').and.callThrough();
+  it('should call onSuspendClick', fakeAsync(() => {
+    const num = 1;
+    const spy = spyOn(component, 'onSuspendClick').and.callThrough();
     component.onSuspendClick(num);
+    tick(20000);
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
       expect(spy).toHaveBeenCalled();
@@ -116,8 +120,8 @@ describe('StartTaskDialogComponent', () => {
   }));
 
   it('should call startTask', async(() => {
-    let num = 1;
-    let spy = spyOn(component, 'startTask').and.callThrough();
+    const num = 1;
+    const spy = spyOn(component, 'startTask').and.callThrough();
     component.startTask(num);
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
@@ -126,8 +130,8 @@ describe('StartTaskDialogComponent', () => {
   }));
 
   it('should call suspendTask', async(() => {
-    let num = 1;
-    let spy = spyOn(component, 'suspendTask').and.callThrough();
+    const num = 1;
+    const spy = spyOn(component, 'suspendTask').and.callThrough();
     component.suspendTask(num);
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
@@ -136,8 +140,8 @@ describe('StartTaskDialogComponent', () => {
   }));
 
   it('should call completeTask', async(() => {
-    let num = 1;
-    let spy = spyOn(component, 'completeTask').and.callThrough();
+    const num = 1;
+    const spy = spyOn(component, 'completeTask').and.callThrough();
     component.completeTask(num);
     fixture.whenStable().then(() => {
       expect(spy).toBeDefined();
@@ -155,7 +159,7 @@ describe('StartTaskDialogComponent', () => {
         });
       }));*/
 
-      it('should be Defined onYesClick', fakeAsync(() => {
+  it('should be Defined onYesClick', fakeAsync(() => {
         spyOn(component, 'onYesClick').and.callThrough();
         fixture.whenStable().then(() => {
           expect(component.onYesClick).toBeDefined();


### PR DESCRIPTION
Updated Unit test "start-task-dialog.spec.ts", imported HTTPTestingModule and this will remove the Jasmine timeout. 